### PR TITLE
Fix image upload null handling

### DIFF
--- a/src/main/java/com/example/blogbackend/service/ImageService.java
+++ b/src/main/java/com/example/blogbackend/service/ImageService.java
@@ -36,12 +36,13 @@ public class ImageService {
 		this.timeProvider = timeProvider;
 	}
 	
-	public ImageDto uploadImage(MultipartFile file, Long blogPostId) {
-		if (file != null && file.isEmpty()) {
-			throw new EmptyFileException(
-					String.format(
-							"File %s is empty, cannot upload the image", file.getOriginalFilename()));
-		}
+        public ImageDto uploadImage(MultipartFile file, Long blogPostId) {
+                if (file == null || file.isEmpty()) {
+                        throw new EmptyFileException(
+                                        String.format(
+                                                        "File %s is empty, cannot upload the image",
+                                                        file == null ? "" : file.getOriginalFilename()));
+                }
 		BlogPost blogPost = blogPostRepository.findById(blogPostId).orElseThrow(
 				() -> new BlogPostNotFoundException("Blog post with id: " + blogPostId + " not found")
 		);

--- a/src/test/java/com/example/blogbackend/service/ImageServiceTest.java
+++ b/src/test/java/com/example/blogbackend/service/ImageServiceTest.java
@@ -83,11 +83,16 @@ public class ImageServiceTest {
 		assertEquals(createdAt, imageDto.createdAt());
 	}
 	
-	@Test(expected = EmptyFileException.class)
-	public void test_uploadImage_emptyFile() {
-		MultipartFile file = new MockMultipartFile("file", "test.jpg", IMAGE_JPEG_VALUE, new byte[0]);
-		imageService.uploadImage(file, 1L);
-	}
+        @Test(expected = EmptyFileException.class)
+        public void test_uploadImage_emptyFile() {
+                MultipartFile file = new MockMultipartFile("file", "test.jpg", IMAGE_JPEG_VALUE, new byte[0]);
+                imageService.uploadImage(file, 1L);
+        }
+
+        @Test(expected = EmptyFileException.class)
+        public void test_uploadImage_nullFile() {
+                imageService.uploadImage(null, 1L);
+        }
 	
 	@Test(expected = ImageUploadException.class)
 	public void test_uploadImage_fileUploadException() {


### PR DESCRIPTION
## Summary
- prevent NullPointerException when uploading images
- test uploading a `null` image
